### PR TITLE
Fix for showing the first totally supported version of each browser

### DIFF
--- a/src/caniuse.php
+++ b/src/caniuse.php
@@ -11,6 +11,7 @@ function browserVersion($stats) {
 	foreach ($stats as $key => $val) {
 		if (!$version && $version < $key && $val == 'y') {
 			$version = $key;
+			break;
 		}
 	}
 	return $version ? $version."+" : "-";


### PR DESCRIPTION
Before, the workflow would always show the latest version no matter what. Now it breaks when it encounters the first _totally_ supported version.
