### PR TITLE
Fix improper version reporting and change check

### DIFF
--- a/src/caniuse.php
+++ b/src/caniuse.php
@@ -6,18 +6,24 @@ $w = new Workflows();
 
 function browserVersion($stats) {
     $version = 0;
+    $support = '';
     foreach ($stats as $key => $val) {
+        $key = floatval($key);
         if ($version < $key && $val == 'y') {
-            $version = $key."+";
+            $support = $key."+";
             break;
-        } elseif ($version < $key && $val == 'y x') {
-            $version = $key."-px-";
-        } elseif ($version < $key && $val == 'p') {
-            $version = $key."+*";
+        } elseif ($version < $key && strpos($val, 'y x') !== false) {
+            $version = $key;
+            $support = $key."-px-";
+        } elseif ($version < $key && strpos($val, 'a') !== false) {
+            $version = $key;
+            $support = $key."!pa.";
+        } elseif ($version < $key && strpos($val, 'p') !== false) {
+            $version = $key;
+            $support = $key."w/pl";
         }
-
     }
-    return $version ? $version : "n/a";
+    return $support ? $support : "n/a";
 }
 
 // cache


### PR DESCRIPTION
Before: ![alfred-caniuse-before](https://cloud.githubusercontent.com/assets/898057/8520607/124458c4-23dc-11e5-84cf-01620fe01cd5.png)

After: ![alfred-caniuse-after](https://cloud.githubusercontent.com/assets/898057/8520610/17908514-23dc-11e5-9748-be6ad60a9e86.png)

The check was invalidated because $version was a string, checking against the version key would not work.
I changed the check to strpos because sometimes there are notes, the whole string wouldn't match.