### PR TITLE
Decode url encoded queries

### DIFF
--- a/src/caniuse.php
+++ b/src/caniuse.php
@@ -79,7 +79,7 @@ function registerResult($result) {
 }
 
 $found = array();
-$query = strtolower(trim($query));
+$query = urldecode(strtolower(trim($query)));
 
 foreach ($data as $key => $result) {
     $value = strtolower(trim($result->title));


### PR DESCRIPTION
First off, thanks a lot for the workflow. As helpful as it is, I've noticed that
the searches don't seem to want to include anything that contained spaces.

After a little digging I've found a potential fix, though as a php noob I'm not
sure if this is the right approach.

Before:

<img width="645" alt="screen shot 2018-01-24 at 17 01 39" src="https://user-images.githubusercontent.com/7091471/35342798-3eaeacac-0129-11e8-9b2e-138a1c04e950.png">

After:

<img width="642" alt="screen shot 2018-01-24 at 17 02 19" src="https://user-images.githubusercontent.com/7091471/35342797-3e7cedca-0129-11e8-996f-d682f2970f4b.png">

Judging by the logs and the workflow's behaviour I couldn't find anything that
the change could break 😄.

Let me know if the PR's good and I'll update it with updated version numbers & exported `.alfredworkflow` file.