### PR TITLE
Deprecated: Function utf8_decode() is deprecated in caniuse.php on line 86 & 67

### DIFF
--- a/src/caniuse.php
+++ b/src/caniuse.php
@@ -83,8 +83,8 @@ $query = urldecode(strtolower(trim($query)));
 
 foreach ($data as $key => $result) {
     $value = strtolower(trim($result->title));
-    $description = utf8_decode(strip_tags($result->description));
-    $keywords = utf8_decode($result->keywords);
+    $description = strip_tags($result->description);
+    $keywords = $result->keywords;
     $name = $result->name;
 
     if (strpos( $value, $query ) === 0) {


### PR DESCRIPTION
Just installed PHP with `brew install php` on macOS 13.2.1 (22D68) and got the following errors

```
Deprecated: Function utf8_decode() is deprecated in caniuse.php on line 86
Deprecated: Function utf8_decode() is deprecated in caniuse.php on line 87
```
Doing a search for the error landed me on https://php.watch/versions/8.2/utf8_encode-utf8_decode-deprecated and after reading:

> ...Passing arbitrary text to utf8_encode function is prone to bugs that do not result in any warnings or errors but may lead to undesired results.

Seemed like an easy solution to edit  the file `caniuse.php` (right click on the workflow > Open in Finder) on those lines removing the `utf8_decode(...)` function made the script work for me again.