### PR TITLE
use mb_convert_encoding

### DIFF
--- a/src/caniuse.php
+++ b/src/caniuse.php
@@ -83,8 +83,8 @@ $query = urldecode(strtolower(trim($query)));
 
 foreach ($data as $key => $result) {
     $value = strtolower(trim($result->title));
-    $description = utf8_decode(strip_tags($result->description));
-    $keywords = utf8_decode($result->keywords);
+    $description = mb_convert_encoding(strip_tags($result->description), 'ISO-8859-1', 'UTF-8');
+    $keywords = mb_convert_encoding($result->keywords, 'ISO-8859-1', 'UTF-8');
     $name = $result->name;
 
     if (strpos( $value, $query ) === 0) {


### PR DESCRIPTION
use `mb_convert_encoding` as `utf8_decode` is deprecated

error message:
Function utf8_decode() is deprecated in /Users/{username}/Library/Application Support/Alfred/Alfred.alfredpreferences/workflows/user.workflow.12C39B24-6C1E-4AFE-98FB-A2E2E0227714/caniuse.php on line 86